### PR TITLE
Make it work in my Python 3.7 virtualenv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
-cmake_minimum_required(VERSION 3.12)
-cmake_policy(VERSION 3.12)
+cmake_minimum_required(VERSION 3.15)
+cmake_policy(VERSION 3.15)
+project(Shiboken2-Qt-Example)
 
 find_package(Qt5 REQUIRED Core)
 
@@ -7,8 +8,6 @@ get_target_property(QtCore_location Qt5::Core LOCATION)
 get_filename_component(QtCore_libdir ${QtCore_location} DIRECTORY)
 
 set(CMAKE_AUTOMOC ON)
-
-project(Shiboken2-Qt-Example)
 
 set(CMAKE_CXX_STANDARD 11)
 set(sample_library "libexamplebinding")
@@ -19,6 +18,7 @@ set(generated_sources
     ${CMAKE_CURRENT_BINARY_DIR}/${bindings_library}/qobjectwithenum_wrapper.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/${bindings_library}/shiboken2qtexample_module_wrapper.cpp)
 
+set(Python3_FIND_VIRTUALENV ONLY)
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
 
 if(NOT python_interpreter)


### PR DESCRIPTION
Most changes are in CMakeLists.txt:

- Moved project command to the beginning. Otherwise it failed to handle it as a C++ project
- Changed cmake minimum version to be able to use the Python3_FIND_VIRTUALENV variable necessary to not mess up with my local Qt

Other changes were to install a wheel dirctly from qt.io because the module was not found by pip:
```
$ wget https://download.qt.io/official_releases/QtForPython/shiboken2-generator/shiboken2_generator-5.15.2-5.15.2-cp35.cp36.cp37.cp38.cp39-abi3-manylinux1_x86_64.whl
$ pip install shiboken2_generator-5.15.2-5.15.2-cp35.cp36.cp37.cp38.cp39-abi3-manylinux1_x86_64.whl
```
And to change my LD_LIBRARY_PATH to point to the PySide lib dir:
```
$ export LD_LIBRARY_PATH=/home/gael/.virtualenvs/pyside/lib/python3.7/site-packages/PySide2/Qt/lib
```
This should probably be made in a more portable manner.

All the steps can be found [here](https://github.com/aymara/lima/issues/123#issuecomment-959504822)